### PR TITLE
CircleCI integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+          - v1-node-modules-{{ checksum "package-lock.json" }}
+          - v1-node-modules-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-node-modules-{{ checksum "package-lock.json" }}
+
+      - run: npm run test


### PR DESCRIPTION
Add the `.circleci/config.yml` file which will allow builds on CircleCI. The file is adapted from the Node template that CircleCI provides.

Right now, the config file just tells CircleCI to install dependencies and run `npm run test` in a Node.js 8 image. Once I make sure everything works, I’d like to also add a code formatting check and test everything with Node.js 9 too. But let’s go one step at a time.