### PR TITLE
Set CircleCI to build with Node.js 8 and 9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  build:
+  build-node-8:
     docker:
       - image: circleci/node:8
 
@@ -12,14 +12,45 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-node-modules-{{ checksum "package-lock.json" }}
-          - v1-node-modules-
+          - v1-node-modules-node-8{{ checksum "package-lock.json" }}
+          - v1-node-modules-node-8
 
       - run: npm install
 
       - save_cache:
           paths:
             - node_modules
-          key: v1-node-modules-{{ checksum "package-lock.json" }}
+          key: v1-node-modules-node-8{{ checksum "package-lock.json" }}
 
       - run: npm run test
+
+  build-node-9:
+    docker:
+      - image: circleci/node:9
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+          - v1-node-modules-node-9{{ checksum "package-lock.json" }}
+          - v1-node-modules-node-9
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-node-modules-node-9{{ checksum "package-lock.json" }}
+
+      - run: npm run test
+
+workflows:
+  version: 2
+
+  build:
+    jobs:
+      - build-node-8
+      - build-node-9


### PR DESCRIPTION
The idea is to build with all supported major Node.js versions.

I chose to duplicate the job config for each Node.js version completely instead of deriving both configs from a common base. The latter was hard to do given that I wanted to have a different package cache key in each config (so that packages installed using Node.js 8 are not used for Node.js 9 builds and vice versa).