### PR TITLE
Check formatting in CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,47 +4,35 @@ jobs:
   build-node-8:
     docker:
       - image: circleci/node:8
-
     working_directory: ~/repo
-
     steps:
       - checkout
-
       - restore_cache:
           keys:
           - v1-node-modules-node-8{{ checksum "package-lock.json" }}
           - v1-node-modules-node-8
-
       - run: npm install
-
       - save_cache:
           paths:
             - node_modules
           key: v1-node-modules-node-8{{ checksum "package-lock.json" }}
-
       - run: npm run test
 
   build-node-9:
     docker:
       - image: circleci/node:9
-
     working_directory: ~/repo
-
     steps:
       - checkout
-
       - restore_cache:
           keys:
           - v1-node-modules-node-9{{ checksum "package-lock.json" }}
           - v1-node-modules-node-9
-
       - run: npm install
-
       - save_cache:
           paths:
             - node_modules
           key: v1-node-modules-node-9{{ checksum "package-lock.json" }}
-
       - run: npm run test
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
           paths:
             - node_modules
           key: v1-node-modules-node-8{{ checksum "package-lock.json" }}
+      - run: npm run format-check
       - run: npm run test
 
   build-node-9:
@@ -33,6 +34,7 @@ jobs:
           paths:
             - node_modules
           key: v1-node-modules-node-9{{ checksum "package-lock.json" }}
+      - run: npm run format-check
       - run: npm run test
 
 workflows:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "repository": "energomonitor/energomonitor-js",
     "scripts": {
         "format": "prettier-eslint --write \"{__tests__,src}/**/*.js\"",
+        "format-check": "prettier-eslint --list-different \"{__tests__,src}/**/*.js\"",
         "test": "jest",
         "test-coverage": "jest --coverage",
         "test-verbose": "jest --verbose",


### PR DESCRIPTION
Add a new `format-check` script and use it in CircleCI builds to check formatting.

@MisRob Not 100% sure about the `format-check` script name, feel free to suggest something else. (My first idea was `check-format`, which sounds more natural, but I like that with `format-check` all formatting-related scripts start with `format`. This is consistent with test-related scripts, which all start with `test`.)